### PR TITLE
Resolve DB paths relative to code location

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -1,10 +1,11 @@
 import os, aiosqlite, json, time
+from pathlib import Path
 import discord
 from discord import app_commands
 from discord.ext import commands
 from datetime import datetime, timezone
 
-DB_PATH = "economy.db"
+DB_PATH = str(Path(__file__).resolve().parent.parent / "economy.db")
 LOG_CHANNEL_ID = int(os.getenv("LOG_CHANNEL_ID", "0") or "0")
 
 async def try_send_log(client: discord.Client, embed: discord.Embed):

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -2,11 +2,12 @@ import os
 import time
 import json
 import aiosqlite
+from pathlib import Path
 import discord
 from discord import app_commands
 from datetime import datetime, timezone, timedelta
 
-DB_PATH = "economy.db"
+DB_PATH = str(Path(__file__).resolve().parent.parent / "economy.db")
 
 # 지급/쿨타임 기본값
 MONEY_COOLDOWN = 600       # 10분

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -1,9 +1,10 @@
 import aiosqlite, secrets, json, time
+from pathlib import Path
 import discord
 from discord import app_commands
 from datetime import datetime, timezone, timedelta
 
-DB_PATH = "economy.db"
+DB_PATH = str(Path(__file__).resolve().parent.parent / "economy.db")
 
 # ── 표시 유틸 ───────────────────────────────────────────
 KST = timezone(timedelta(hours=9))

--- a/main.py
+++ b/main.py
@@ -1,12 +1,13 @@
 # main.py
 import os
+from pathlib import Path
 import discord
 from discord.ext import commands
 from discord import app_commands
 from dotenv import load_dotenv
 import aiosqlite
 
-DB_PATH = "economy.db"
+DB_PATH = str(Path(__file__).resolve().parent / "economy.db")
 
 # ───────── 번역기 ─────────
 class MZTranslator(app_commands.Translator):


### PR DESCRIPTION
## Summary
- compute DB_PATH using `Path(__file__).resolve()` in admin, economy, games cogs and main module
- ensure economy cog is properly named for extension loading

## Testing
- `python -m py_compile cogs/admin.py cogs/economy.py cogs/games.py main.py`
- `python - <<'PY'
import os, sys, asyncio, aiosqlite
os.chdir('/tmp')
sys.path.append('/workspace/MZ_bot')
import cogs.admin as admin
import cogs.games as games
import cogs.economy as economy
async def check():
    for mod in (admin, games, economy):
        async with aiosqlite.connect(mod.DB_PATH) as db:
            await db.execute('SELECT 1')
asyncio.run(check())
print('admin', admin.DB_PATH)
print('games', games.DB_PATH)
print('economy', economy.DB_PATH)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68969800ac248327a76460c470d82a9d