### PR TITLE
docs: expand README with setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # MZ_bot
-디스코드 도박봇
+
+Discord 기반 경제/도박 봇입니다.
+
+## 요구 사항
+- Python 3.10 이상
+- Discord 봇 토큰
+
+## 설치
+```bash
+pip install -r requirements.txt
+```
+
+## 실행
+1. `.env` 파일을 생성하고 다음 값을 설정합니다.
+   ```env
+   DISCORD_TOKEN=봇_토큰
+   DEV_GUILD_ID=개발_길드_ID(옵션)
+   OWNER_ID=봇_소유자_ID(옵션)
+   ```
+2. 봇을 실행합니다.
+   ```bash
+   python main.py
+   ```
+
+## 주요 기능
+- 10분마다 기본 코인 지급
+- 출석 보상, 송금 및 잔액 조회
+- 베팅과 순위 확인 등 경제 시스템
+- 관리자 전용 설정 및 질의응답 기능


### PR DESCRIPTION
## Summary
- add installation, configuration, and usage instructions
- document key features of the Discord economy bot

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68974a265a948327a9c06344531a9729